### PR TITLE
fix: add `gutterForeground` for readable line numbers

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -25,6 +25,7 @@ export const convert = (vscTheme: VSCTheme, uuid: string) => {
           selection: colors["editor.selectionBackground"],
           activeGuide: colors["editorIndentGuide.background"],
           findHighlight: colors["editor.findMatchHighlightBackground"],
+          gutterForeground: colors["editorLineNumber.foreground"],
         },
       },
       ...vscTheme.tokenColors.map((tokenColor) => {

--- a/themes/Catppuccin Frappe.tmTheme
+++ b/themes/Catppuccin Frappe.tmTheme
@@ -35,6 +35,8 @@
           <string>#51576d</string>
           <key>findHighlight</key>
           <string>#506373</string>
+          <key>gutterForeground</key>
+          <string>#838ba7</string>
         </dict>
       </dict>
       <dict>

--- a/themes/Catppuccin Latte.tmTheme
+++ b/themes/Catppuccin Latte.tmTheme
@@ -35,6 +35,8 @@
           <string>#bcc0cc</string>
           <key>findHighlight</key>
           <string>#a9daf0</string>
+          <key>gutterForeground</key>
+          <string>#8c8fa1</string>
         </dict>
       </dict>
       <dict>

--- a/themes/Catppuccin Macchiato.tmTheme
+++ b/themes/Catppuccin Macchiato.tmTheme
@@ -35,6 +35,8 @@
           <string>#494d64</string>
           <key>findHighlight</key>
           <string>#455c6d</string>
+          <key>gutterForeground</key>
+          <string>#8087a2</string>
         </dict>
       </dict>
       <dict>

--- a/themes/Catppuccin Mocha.tmTheme
+++ b/themes/Catppuccin Mocha.tmTheme
@@ -35,6 +35,8 @@
           <string>#45475a</string>
           <key>findHighlight</key>
           <string>#3e5767</string>
+          <key>gutterForeground</key>
+          <string>#7f849c</string>
         </dict>
       </dict>
       <dict>


### PR DESCRIPTION
When using any of these themes `gutterForeground` is not set and falls back to the default (#444444). This applies to the gutter line numbers and decorations. It's straining to read on a darker background or any of the Catppuccin themes (except Latte).

Kitty terminal and bat, both with Catppuccin Frappe (without & with `gutterForeground`):
![screenshot-2024-03-07T10:37:25](https://github.com/catppuccin/bat/assets/33635402/558ef896-bca7-4c22-a6dc-d24539b79345)
