### PR TITLE
feat(manpage): highlight options

### DIFF
--- a/themes/Catppuccin Frappe.tmTheme
+++ b/themes/Catppuccin Frappe.tmTheme
@@ -276,7 +276,7 @@
         <key>name</key>
         <string>Namespaces</string>
         <key>scope</key>
-        <string>entity.name.namespace</string>
+        <string>entity.name.namespace, entity.name</string>
         <key>settings</key>
         <dict>
           <key>foreground</key>

--- a/themes/Catppuccin Latte.tmTheme
+++ b/themes/Catppuccin Latte.tmTheme
@@ -276,7 +276,7 @@
         <key>name</key>
         <string>Namespaces</string>
         <key>scope</key>
-        <string>entity.name.namespace</string>
+        <string>entity.name.namespace, entity.name</string>
         <key>settings</key>
         <dict>
           <key>foreground</key>

--- a/themes/Catppuccin Macchiato.tmTheme
+++ b/themes/Catppuccin Macchiato.tmTheme
@@ -276,7 +276,7 @@
         <key>name</key>
         <string>Namespaces</string>
         <key>scope</key>
-        <string>entity.name.namespace</string>
+        <string>entity.name.namespace, entity.name</string>
         <key>settings</key>
         <dict>
           <key>foreground</key>

--- a/themes/Catppuccin Mocha.tmTheme
+++ b/themes/Catppuccin Mocha.tmTheme
@@ -276,7 +276,7 @@
         <key>name</key>
         <string>Namespaces</string>
         <key>scope</key>
-        <string>entity.name.namespace</string>
+        <string>entity.name.namespace, entity.name</string>
         <key>settings</key>
         <dict>
           <key>foreground</key>


### PR DESCRIPTION
I felt these were missing from the current man support. I just kinda picked the first color that made sense to me, please correct me if there is a more suitable color in the themes. 

Before:
![before](https://github.com/catppuccin/bat/assets/28459732/b2e396c9-78c7-4bb1-a99e-a895e4670fe5)

After:
![after](https://github.com/catppuccin/bat/assets/28459732/c5e94d25-0fc5-46cb-8510-7cbf6df32ffa)
