### PR TITLE
Add MacOS related instruction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,23 @@ mkdir -p "$(bat --config-dir)/themes"
 
 2. Copy the theme files from this repository:
 
+**Linux**
+
 ```bash
 wget -P "$(bat --config-dir)/themes" https://github.com/catppuccin/bat/raw/main/themes/Catppuccin%20Latte.tmTheme
 wget -P "$(bat --config-dir)/themes" https://github.com/catppuccin/bat/raw/main/themes/Catppuccin%20Frappe.tmTheme
 wget -P "$(bat --config-dir)/themes" https://github.com/catppuccin/bat/raw/main/themes/Catppuccin%20Macchiato.tmTheme
 wget -P "$(bat --config-dir)/themes" https://github.com/catppuccin/bat/raw/main/themes/Catppuccin%20Mocha.tmTheme
 ```
+
+**Mac OS**
+```bash
+curl -L -o "$(bat --config-dir)/themes/Catppuccin Latte.tmTheme" https://github.com/catppuccin/bat/raw/main/themes/Catppuccin%20Latte.tmTheme
+curl -L -o "$(bat --config-dir)/themes/Catppuccin Frappe.tmTheme" https://github.com/catppuccin/bat/raw/main/themes/Catppuccin%20Frappe.tmTheme
+curl -L -o "$(bat --config-dir)/themes/Catppuccin Macchiato.tmTheme" https://github.com/catppuccin/bat/raw/main/themes/Catppuccin%20Macchiato.tmTheme
+curl -L -o "$(bat --config-dir)/themes/Catppuccin Mocha.tmTheme" https://github.com/catppuccin/bat/raw/main/themes/Catppuccin%20Mocha.tmTheme
+```
+
 
 3. Rebuild bat's cache:
 


### PR DESCRIPTION
Issue: 
- For Mac OS, you need to use `curl` instead of `wget` to download and save the files to the designated folder.