### PR TITLE
fix(json): add blue color highlighting for JSON keys (#30)

### DIFF
--- a/src/syntaxes/index.ts
+++ b/src/syntaxes/index.ts
@@ -1,10 +1,12 @@
 import { type Palette } from "../convert.ts";
 import { type VSCTheme } from "../main.ts";
 
+import json from "./json.ts";
 import man from "./man.ts";
 import markdown from "./markdown.ts";
 
 export const customTokens = (p: Palette): VSCTheme["tokenColors"] => [
+  ...json(p),
   ...man(p),
   ...markdown(p),
 ];

--- a/src/syntaxes/json.ts
+++ b/src/syntaxes/json.ts
@@ -1,0 +1,22 @@
+import { type Palette } from "../convert.ts";
+import { type VSCTheme } from "../main.ts";
+
+export default (p: Palette): VSCTheme["tokenColors"] => [
+  {
+    name: "JSON Keys",
+    scope: ["source.json meta.mapping.key string"],
+    settings: {
+      foreground: p.blue,
+    },
+  },
+  {
+    name: "JSON key surrounding quotes",
+    scope: [
+      "source.json meta.mapping.key punctuation.definition.string.begin",
+      "source.json meta.mapping.key punctuation.definition.string.end",
+    ],
+    settings: {
+      foreground: p.overlay2,
+    },
+  },
+];

--- a/themes/Catppuccin Frappe.tmTheme
+++ b/themes/Catppuccin Frappe.tmTheme
@@ -1990,6 +1990,28 @@
         </dict>
       </dict>
       <dict>
+        <key>name</key>
+        <string>JSON Keys</string>
+        <key>scope</key>
+        <string>source.json meta.mapping.key string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8caaee</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON key surrounding quotes</string>
+        <key>scope</key>
+        <string>source.json meta.mapping.key punctuation.definition.string.begin, source.json meta.mapping.key punctuation.definition.string.end</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#949cbb</string>
+        </dict>
+      </dict>
+      <dict>
         <key>scope</key>
         <string>markup.heading.synopsis.man, markup.heading.title.man, markup.heading.other.man, markup.heading.env.man</string>
         <key>settings</key>

--- a/themes/Catppuccin Latte.tmTheme
+++ b/themes/Catppuccin Latte.tmTheme
@@ -1990,6 +1990,28 @@
         </dict>
       </dict>
       <dict>
+        <key>name</key>
+        <string>JSON Keys</string>
+        <key>scope</key>
+        <string>source.json meta.mapping.key string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#1e66f5</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON key surrounding quotes</string>
+        <key>scope</key>
+        <string>source.json meta.mapping.key punctuation.definition.string.begin, source.json meta.mapping.key punctuation.definition.string.end</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#7c7f93</string>
+        </dict>
+      </dict>
+      <dict>
         <key>scope</key>
         <string>markup.heading.synopsis.man, markup.heading.title.man, markup.heading.other.man, markup.heading.env.man</string>
         <key>settings</key>

--- a/themes/Catppuccin Macchiato.tmTheme
+++ b/themes/Catppuccin Macchiato.tmTheme
@@ -1990,6 +1990,28 @@
         </dict>
       </dict>
       <dict>
+        <key>name</key>
+        <string>JSON Keys</string>
+        <key>scope</key>
+        <string>source.json meta.mapping.key string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#8aadf4</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON key surrounding quotes</string>
+        <key>scope</key>
+        <string>source.json meta.mapping.key punctuation.definition.string.begin, source.json meta.mapping.key punctuation.definition.string.end</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#939ab7</string>
+        </dict>
+      </dict>
+      <dict>
         <key>scope</key>
         <string>markup.heading.synopsis.man, markup.heading.title.man, markup.heading.other.man, markup.heading.env.man</string>
         <key>settings</key>

--- a/themes/Catppuccin Mocha.tmTheme
+++ b/themes/Catppuccin Mocha.tmTheme
@@ -1990,6 +1990,28 @@
         </dict>
       </dict>
       <dict>
+        <key>name</key>
+        <string>JSON Keys</string>
+        <key>scope</key>
+        <string>source.json meta.mapping.key string</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#89b4fa</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>JSON key surrounding quotes</string>
+        <key>scope</key>
+        <string>source.json meta.mapping.key punctuation.definition.string.begin, source.json meta.mapping.key punctuation.definition.string.end</string>
+        <key>settings</key>
+        <dict>
+          <key>foreground</key>
+          <string>#9399b2</string>
+        </dict>
+      </dict>
+      <dict>
         <key>scope</key>
         <string>markup.heading.synopsis.man, markup.heading.title.man, markup.heading.other.man, markup.heading.env.man</string>
         <key>settings</key>


### PR DESCRIPTION
This fix adds blue highlighting to JSON keys with overlay 2 coloring for the quotes, the same as it is in the [Sublime theme](https://github.com/catppuccin/sublime-text).

Fixes: #30 